### PR TITLE
Add regexp extract function

### DIFF
--- a/datafusion/functions/src/regex/mod.rs
+++ b/datafusion/functions/src/regex/mod.rs
@@ -23,11 +23,11 @@ use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::sync::Arc;
 pub mod regexpcount;
+pub mod regexpextract;
 pub mod regexpinstr;
 pub mod regexplike;
 pub mod regexpmatch;
 pub mod regexpreplace;
-pub mod regexpextract;
 
 // create UDFs
 make_udf_function!(regexpcount::RegexpCountFunc, regexp_count);

--- a/datafusion/functions/src/regex/mod.rs
+++ b/datafusion/functions/src/regex/mod.rs
@@ -27,6 +27,7 @@ pub mod regexpinstr;
 pub mod regexplike;
 pub mod regexpmatch;
 pub mod regexpreplace;
+pub mod regexpextract;
 
 // create UDFs
 make_udf_function!(regexpcount::RegexpCountFunc, regexp_count);
@@ -34,6 +35,7 @@ make_udf_function!(regexpinstr::RegexpInstrFunc, regexp_instr);
 make_udf_function!(regexpmatch::RegexpMatchFunc, regexp_match);
 make_udf_function!(regexplike::RegexpLikeFunc, regexp_like);
 make_udf_function!(regexpreplace::RegexpReplaceFunc, regexp_replace);
+make_udf_function!(regexpextract::RegexpExtractFunc, regexp_extract);
 
 pub mod expr_fn {
     use datafusion_expr::Expr;
@@ -115,6 +117,20 @@ pub mod expr_fn {
         };
         super::regexp_replace().call(args)
     }
+
+    /// Extract a single match from a string
+    pub fn regexp_extract(
+        string: Expr,
+        pattern: Expr,
+        index: Expr,
+        flags: Option<Expr>,
+    ) -> Expr {
+        let mut args = vec![string, pattern, index];
+        if let Some(flags) = flags {
+            args.push(flags);
+        };
+        super::regexp_extract().call(args)
+    }
 }
 
 /// Returns all DataFusion functions defined in this package
@@ -125,6 +141,7 @@ pub fn functions() -> Vec<Arc<datafusion_expr::ScalarUDF>> {
         regexp_instr(),
         regexp_like(),
         regexp_replace(),
+        regexp_extract(),
     ]
 }
 

--- a/datafusion/functions/src/regex/regexpextract.rs
+++ b/datafusion/functions/src/regex/regexpextract.rs
@@ -17,10 +17,10 @@
 
 use crate::regex::{compile_and_cache_regex, compile_regex};
 use arrow::array::{
-    Array, ArrayRef, AsArray, Datum, GenericStringArray, Int64Array, StringArrayType,
-    StringViewArray,
+    Array, ArrayRef, AsArray, Datum, GenericStringArray, Int32Array, Int64Array,
+    StringArrayType, StringViewArray,
 };
-use arrow::datatypes::{DataType, Int64Type};
+use arrow::datatypes::{DataType, Int32Type};
 use arrow::datatypes::{
     DataType::Int64, DataType::LargeUtf8, DataType::Utf8, DataType::Utf8View,
 };
@@ -203,7 +203,7 @@ pub fn regexp_extract(
             values.as_string::<i32>(),
             regex_array.as_string::<i32>(),
             is_regex_scalar,
-            idx_array.as_primitive::<Int64Type>(),
+            idx_array.as_primitive::<Int32Type>(),
             is_idx_scalar,
             None,
             is_flags_scalar,
@@ -212,7 +212,7 @@ pub fn regexp_extract(
             values.as_string::<i32>(),
             regex_array.as_string::<i32>(),
             is_regex_scalar,
-            idx_array.as_primitive::<Int64Type>(),
+            idx_array.as_primitive::<Int32Type>(),
             is_idx_scalar,
             Some(flags_array.as_string::<i32>()),
             is_flags_scalar,
@@ -221,7 +221,7 @@ pub fn regexp_extract(
             values.as_string::<i64>(),
             regex_array.as_string::<i64>(),
             is_regex_scalar,
-            idx_array.as_primitive::<Int64Type>(),
+            idx_array.as_primitive::<Int32Type>(),
             is_idx_scalar,
             None,
             is_flags_scalar,
@@ -230,7 +230,7 @@ pub fn regexp_extract(
             values.as_string::<i64>(),
             regex_array.as_string::<i64>(),
             is_regex_scalar,
-            idx_array.as_primitive::<Int64Type>(),
+            idx_array.as_primitive::<Int32Type>(),
             is_idx_scalar,
             Some(flags_array.as_string::<i64>()),
             is_flags_scalar,
@@ -239,7 +239,7 @@ pub fn regexp_extract(
             values.as_string_view(),
             regex_array.as_string_view(),
             is_regex_scalar,
-            idx_array.as_primitive::<Int64Type>(),
+            idx_array.as_primitive::<Int32Type>(),
             is_idx_scalar,
             None,
             is_flags_scalar,
@@ -248,7 +248,7 @@ pub fn regexp_extract(
             values.as_string_view(),
             regex_array.as_string_view(),
             is_regex_scalar,
-            idx_array.as_primitive::<Int64Type>(),
+            idx_array.as_primitive::<Int32Type>(),
             is_idx_scalar,
             Some(flags_array.as_string_view()),
             is_flags_scalar,
@@ -263,7 +263,7 @@ pub fn regexp_extract_inner<'a, S>(
     values: S,
     regex_array: S,
     is_regex_scalar: bool,
-    idx_array: &Int64Array,
+    idx_array: &Int32Array,
     is_idx_scalar: bool,
     flags_array: Option<S>,
     is_flags_scalar: bool,
@@ -535,7 +535,7 @@ where
 fn extract_match<'v>(
     value: Option<&'v str>,
     pattern: &Regex,
-    idx: Option<i64>,
+    idx: Option<i32>,
 ) -> Result<&'v str, ArrowError> {
     let value = match value {
         None | Some("") => return Ok(""),
@@ -557,7 +557,7 @@ fn extract_match<'v>(
     Ok(capture.unwrap_or(""))
 }
 
-fn extract_match_inner<'v>(value: &'v str, pattern: &Regex, idx: i64) -> Option<&'v str> {
+fn extract_match_inner<'v>(value: &'v str, pattern: &Regex, idx: i32) -> Option<&'v str> {
     Some(pattern.captures(value)?.get(idx as usize)?.as_str())
 }
 
@@ -583,5 +583,85 @@ fn collect_to_array<'a>(
         }
         other => exec_err!("Unsupported data type {other:?} for function regex_replace")
             .map_err(Into::into),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use arrow::datatypes::Field;
+    use datafusion_common::config::ConfigOptions;
+    use datafusion_expr::ScalarFunctionArgs;
+
+    use super::*;
+
+    #[test]
+    fn test_case_sensitive_regexp_extract_scalar() {
+        let values = ["aaaac", "ac", "abc", "abcccc", "abbc"];
+        let regex = "(a+)(b)?(c)";
+        let idx = ScalarValue::Int32(Some(2));
+        let expected: Vec<String> = vec![
+            "".to_string(),
+            "".to_string(),
+            "b".to_string(),
+            "b".to_string(),
+            "".to_string(),
+        ];
+
+        values.iter().enumerate().for_each(|(pos, &v)| {
+            // utf8
+            let v_sv = ScalarValue::Utf8(Some(v.to_string()));
+            let regex_sv = ScalarValue::Utf8(Some(regex.to_string()));
+            let expected = expected.get(pos).cloned();
+            let re = regexp_extract_with_scalar_values(&[v_sv, regex_sv, idx.clone()]);
+            match re {
+                Ok(ColumnarValue::Scalar(ScalarValue::Utf8(v))) => {
+                    assert_eq!(v, expected, "regexp_extract scalar test failed");
+                }
+                o => panic!("Unexpected result: {o:?}"),
+            }
+
+            // largeutf8
+            let v_sv = ScalarValue::LargeUtf8(Some(v.to_string()));
+            let regex_sv = ScalarValue::LargeUtf8(Some(regex.to_string()));
+            let re = regexp_extract_with_scalar_values(&[v_sv, regex_sv, idx.clone()]);
+            match re {
+                Ok(ColumnarValue::Scalar(ScalarValue::LargeUtf8(v))) => {
+                    assert_eq!(v, expected, "regexp_extract scalar test failed");
+                }
+                o => panic!("Unexpected result: {o:?}"),
+            }
+
+            // utf8view
+            let v_sv = ScalarValue::Utf8View(Some(v.to_string()));
+            let regex_sv = ScalarValue::Utf8View(Some(regex.to_string()));
+            let re = regexp_extract_with_scalar_values(&[v_sv, regex_sv, idx.clone()]);
+            match re {
+                Ok(ColumnarValue::Scalar(ScalarValue::Utf8View(v))) => {
+                    assert_eq!(v, expected, "regexp_extract scalar test failed");
+                }
+                o => panic!("Unexpected result: {o:?}"),
+            }
+        });
+    }
+
+    fn regexp_extract_with_scalar_values(args: &[ScalarValue]) -> Result<ColumnarValue> {
+        let args_values = args
+            .iter()
+            .map(|sv| ColumnarValue::Scalar(sv.clone()))
+            .collect();
+
+        let arg_fields = args
+            .iter()
+            .enumerate()
+            .map(|(idx, a)| Field::new(format!("arg_{idx}"), a.data_type(), true).into())
+            .collect::<Vec<_>>();
+
+        RegexpExtractFunc::new().invoke_with_args(ScalarFunctionArgs {
+            args: args_values,
+            arg_fields,
+            number_rows: args.len(),
+            return_field: Field::new("f", args[0].data_type(), true).into(),
+            config_options: Arc::new(ConfigOptions::default()),
+        })
     }
 }

--- a/datafusion/functions/src/regex/regexpextract.rs
+++ b/datafusion/functions/src/regex/regexpextract.rs
@@ -1,0 +1,563 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::regex::{compile_and_cache_regex, compile_regex};
+use arrow::array::{Array, ArrayRef, AsArray, Datum, Int64Array, StringArrayType};
+use arrow::datatypes::{DataType, Int64Type};
+use arrow::datatypes::{
+    DataType::Int64, DataType::LargeUtf8, DataType::Utf8, DataType::Utf8View,
+};
+use arrow::error::ArrowError;
+use datafusion_common::{exec_err, internal_err, Result, ScalarValue};
+use datafusion_expr::{
+    ColumnarValue, Documentation, ScalarUDFImpl, Signature, TypeSignature::Exact, Volatility,
+};
+use datafusion_macros::user_doc;
+use itertools::izip;
+use regex::Regex;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+#[user_doc(
+    doc_section(label = "Regular Expression Functions"),
+    description = "Extracts a specific group matched by a [regular expression](https://docs.rs/regex/latest/regex/#syntax) in a string.",
+    syntax_example = "regexp_extract(str, regexp, idx[, flags])",
+    sql_example = r#"```sql
+> select regexp_extract('abcAbAbc', 'abc', 2, 'i');
++-------------------------------------------------------------------+
+| regexp_extract(Utf8("abcAbAbc"),Utf8("(abc)"),Int64(1),Utf8("i")) |
++-------------------------------------------------------------------+
+| abc                                                               |
++-------------------------------------------------------------------+
+```"#,
+    standard_argument(name = "str", prefix = "String"),
+    standard_argument(name = "regexp", prefix = "Regular"),
+    argument(
+        name = "idx",
+        description = "- **idx**: The index of the matched group to extract."
+    ),
+    argument(
+        name = "flags",
+        description = r#"Optional regular expression flags that control the behavior of the regular expression. The following flags are supported:
+  - **i**: case-insensitive: letters match both upper and lower case
+  - **m**: multi-line mode: ^ and $ match begin/end of line
+  - **s**: allow . to match \n
+  - **R**: enables CRLF mode: when multi-line mode is enabled, \r\n is used
+  - **U**: swap the meaning of x* and x*?"#
+    )
+)]
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct RegexpExtractFunc {
+    signature: Signature,
+}
+
+impl Default for RegexpExtractFunc {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RegexpExtractFunc {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::one_of(
+                vec![
+                    Exact(vec![Utf8View, Utf8View, Int64]),
+                    Exact(vec![LargeUtf8, LargeUtf8, Int64]),
+                    Exact(vec![Utf8, Utf8, Int64]),
+                    Exact(vec![Utf8View, Utf8View, Int64, Utf8View]),
+                    Exact(vec![LargeUtf8, LargeUtf8, Int64, LargeUtf8]),
+                    Exact(vec![Utf8, Utf8, Int64, Utf8]),
+                ],
+                Volatility::Immutable,
+            ),
+        }
+    }
+}
+
+impl ScalarUDFImpl for RegexpExtractFunc {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "regexp_extract"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+        Ok(arg_types[0].clone())
+    }
+
+    fn invoke_with_args(
+        &self,
+        args: datafusion_expr::ScalarFunctionArgs,
+    ) -> Result<ColumnarValue> {
+        let args = &args.args;
+
+        let len = args
+            .iter()
+            .fold(Option::<usize>::None, |acc, arg| match arg {
+                ColumnarValue::Scalar(_) => acc,
+                ColumnarValue::Array(a) => Some(a.len()),
+            });
+
+        let is_scalar = len.is_none();
+        let inferred_length = len.unwrap_or(1);
+        let args = args
+            .iter()
+            .map(|arg| arg.to_array(inferred_length))
+            .collect::<Result<Vec<_>>>()?;
+
+        let result = regexp_extract_func(&args);
+        if is_scalar {
+            // If all inputs are scalar, keeps output as scalar
+            let result = result.and_then(|arr| ScalarValue::try_from_array(&arr, 0));
+            result.map(ColumnarValue::Scalar)
+        } else {
+            result.map(ColumnarValue::Array)
+        }
+    }
+
+    fn documentation(&self) -> Option<&Documentation> {
+        self.doc()
+    }
+}
+
+pub fn regexp_extract_func(args: &[ArrayRef]) -> Result<ArrayRef> {
+    let args_len = args.len();
+    if !(3..=4).contains(&args_len) {
+        return exec_err!("regexp_extract was called with {args_len} arguments. It requires at least 3 and at most 4.");
+    }
+
+    let values = &args[0];
+    match values.data_type() {
+        Utf8 | LargeUtf8 | Utf8View => (),
+        other => {
+            return internal_err!(
+                "Unsupported data type {other:?} for function regexp_extract"
+            );
+        }
+    }
+
+    regexp_extract(
+        values,
+        &args[1],
+        &args[2],
+        if args_len > 3 { Some(&args[3]) } else { None },
+    )
+    .map_err(|e| e.into())
+}
+
+/// `arrow-rs` style implementation of `regexp_extract` function.
+/// This function `regexp_extract` is responsible for extracting a single matching group of a regular expression pattern
+/// within a string array. It supports optional flags for case insensitivity.
+///
+/// The function accepts a variable number of arguments:
+/// - `values`: The array of strings to search within.
+/// - `regex_array`: The array of regular expression patterns to search for.
+/// - `idx`: The index of a group inside the regular expression to extract.
+/// - `flags_array` (optional): The array of flags to modify the search behavior (e.g., case insensitivity).
+///
+/// The function handles different combinations of scalar and array inputs for the regex patterns, group ids,
+/// and flags. It uses a cache to store compiled regular expressions for efficiency.
+///
+/// # Errors
+/// Returns an error if the input arrays have mismatched lengths or if the regular expression fails to compile.
+pub fn regexp_extract(
+    values: &dyn Array,
+    regex_array: &dyn Datum,
+    idx_array: &dyn Datum,
+    flags_array: Option<&dyn Datum>,
+) -> Result<ArrayRef, ArrowError> {
+    let (regex_array, is_regex_scalar) = regex_array.get();
+    let (idx_array, is_idx_scalar) = idx_array.get();
+    let (flags_array, is_flags_scalar) = flags_array.map_or((None, true), |flags| {
+        let (flags, is_flags_scalar) = flags.get();
+        (Some(flags), is_flags_scalar)
+    });
+
+    match (values.data_type(), regex_array.data_type(), flags_array) {
+        (Utf8, Utf8, None) => regexp_extract_inner(
+            values.as_string::<i32>(),
+            regex_array.as_string::<i32>(),
+            is_regex_scalar,
+            idx_array.as_primitive::<Int64Type>(),
+            is_idx_scalar,
+            None,
+            is_flags_scalar,
+        ),
+        (Utf8, Utf8, Some(flags_array)) if *flags_array.data_type() == Utf8 => regexp_extract_inner(
+            values.as_string::<i32>(),
+            regex_array.as_string::<i32>(),
+            is_regex_scalar,
+            idx_array.as_primitive::<Int64Type>(),
+            is_idx_scalar,
+            Some(flags_array.as_string::<i32>()),
+            is_flags_scalar,
+        ),
+        (LargeUtf8, LargeUtf8, None) => regexp_extract_inner(
+            values.as_string::<i64>(),
+            regex_array.as_string::<i64>(),
+            is_regex_scalar,
+            idx_array.as_primitive::<Int64Type>(),
+            is_idx_scalar,
+            None,
+            is_flags_scalar,
+        ),
+        (LargeUtf8, LargeUtf8, Some(flags_array)) if *flags_array.data_type() == LargeUtf8 => regexp_extract_inner(
+            values.as_string::<i64>(),
+            regex_array.as_string::<i64>(),
+            is_regex_scalar,
+            idx_array.as_primitive::<Int64Type>(),
+            is_idx_scalar,
+            Some(flags_array.as_string::<i64>()),
+            is_flags_scalar,
+        ),
+        (Utf8View, Utf8View, None) => regexp_extract_inner(
+            values.as_string_view(),
+            regex_array.as_string_view(),
+            is_regex_scalar,
+            idx_array.as_primitive::<Int64Type>(),
+            is_idx_scalar,
+            None,
+            is_flags_scalar,
+        ),
+        (Utf8View, Utf8View, Some(flags_array)) if *flags_array.data_type() == Utf8View => regexp_extract_inner(
+            values.as_string_view(),
+            regex_array.as_string_view(),
+            is_regex_scalar,
+            idx_array.as_primitive::<Int64Type>(),
+            is_idx_scalar,
+            Some(flags_array.as_string_view()),
+            is_flags_scalar,
+        ),
+        _ => Err(ArrowError::ComputeError(
+            "regexp_extract() expected the input arrays to be of type Utf8, LargeUtf8, or Utf8View and the data types of the values, regex_array, and flags_array to match".to_string(),
+        )),
+    }
+}
+
+pub fn regexp_extract_inner<'a, S>(
+    values: S,
+    regex_array: S,
+    is_regex_scalar: bool,
+    idx_array: &Int64Array,
+    is_idx_scalar: bool,
+    flags_array: Option<S>,
+    is_flags_scalar: bool,
+) -> Result<ArrayRef, ArrowError>
+where
+    S: StringArrayType<'a>,
+{
+    let (regex_scalar, is_regex_scalar) = if is_regex_scalar || regex_array.len() == 1 {
+        (Some(regex_array.value(0)), true)
+    } else {
+        (None, false)
+    };
+
+    let (idx_scalar, is_idx_scalar) = if is_idx_scalar || idx_array.len() == 1 {
+        (Some(idx_array.value(0)), true)
+    } else {
+        (None, false)
+    };
+
+    let (flags_array, flags_scalar, is_flags_scalar) =
+        if let Some(flags_array) = flags_array {
+            if is_flags_scalar || flags_array.len() == 1 {
+                (None, Some(flags_array.value(0)), true)
+            } else {
+                (Some(flags_array), None, false)
+            }
+        } else {
+            (None, None, true)
+        };
+
+    let mut regex_cache = HashMap::new();
+
+    match (is_regex_scalar, is_idx_scalar, is_flags_scalar) {
+        (true, true, true) => {
+            let regex = match regex_scalar {
+                None | Some("") => {
+                    return Ok(Arc::new(Int64Array::from(vec![0; values.len()])))
+                }
+                Some(regex) => regex,
+            };
+
+            let pattern = compile_regex(regex, flags_scalar)?;
+
+            Ok(Arc::new(
+                values
+                    .iter()
+                    .map(|value| count_matches(value, &pattern, idx_scalar))
+                    .collect::<Result<Int64Array, ArrowError>>()?,
+            ))
+        }
+        (true, true, false) => {
+            let regex = match regex_scalar {
+                None | Some("") => {
+                    return Ok(Arc::new(Int64Array::from(vec![0; values.len()])))
+                }
+                Some(regex) => regex,
+            };
+
+            let flags_array = flags_array.unwrap();
+            if values.len() != flags_array.len() {
+                return Err(ArrowError::ComputeError(format!(
+                    "flags_array must be the same length as values array; got {} and {}",
+                    flags_array.len(),
+                    values.len(),
+                )));
+            }
+
+            Ok(Arc::new(
+                values
+                    .iter()
+                    .zip(flags_array.iter())
+                    .map(|(value, flags)| {
+                        let pattern =
+                            compile_and_cache_regex(regex, flags, &mut regex_cache)?;
+                        count_matches(value, pattern, idx_scalar)
+                    })
+                    .collect::<Result<Int64Array, ArrowError>>()?,
+            ))
+        }
+        (true, false, true) => {
+            let regex = match regex_scalar {
+                None | Some("") => {
+                    return Ok(Arc::new(Int64Array::from(vec![0; values.len()])))
+                }
+                Some(regex) => regex,
+            };
+
+            let pattern = compile_regex(regex, flags_scalar)?;
+
+            Ok(Arc::new(
+                values
+                    .iter()
+                    .zip(idx_array.iter())
+                    .map(|(value, start)| count_matches(value, &pattern, start))
+                    .collect::<Result<Int64Array, ArrowError>>()?,
+            ))
+        }
+        (true, false, false) => {
+            let regex = match regex_scalar {
+                None | Some("") => {
+                    return Ok(Arc::new(Int64Array::from(vec![0; values.len()])))
+                }
+                Some(regex) => regex,
+            };
+
+            let flags_array = flags_array.unwrap();
+            if values.len() != flags_array.len() {
+                return Err(ArrowError::ComputeError(format!(
+                    "flags_array must be the same length as values array; got {} and {}",
+                    flags_array.len(),
+                    values.len(),
+                )));
+            }
+
+            Ok(Arc::new(
+                izip!(
+                    values.iter(),
+                    idx_array.iter(),
+                    flags_array.iter()
+                )
+                .map(|(value, start, flags)| {
+                    let pattern =
+                        compile_and_cache_regex(regex, flags, &mut regex_cache)?;
+
+                    count_matches(value, pattern, start)
+                })
+                .collect::<Result<Int64Array, ArrowError>>()?,
+            ))
+        }
+        (false, true, true) => {
+            if values.len() != regex_array.len() {
+                return Err(ArrowError::ComputeError(format!(
+                    "regex_array must be the same length as values array; got {} and {}",
+                    regex_array.len(),
+                    values.len(),
+                )));
+            }
+
+            Ok(Arc::new(
+                values
+                    .iter()
+                    .zip(regex_array.iter())
+                    .map(|(value, regex)| {
+                        let regex = match regex {
+                            None | Some("") => return Ok(0),
+                            Some(regex) => regex,
+                        };
+
+                        let pattern = compile_and_cache_regex(
+                            regex,
+                            flags_scalar,
+                            &mut regex_cache,
+                        )?;
+                        count_matches(value, pattern, idx_scalar)
+                    })
+                    .collect::<Result<Int64Array, ArrowError>>()?,
+            ))
+        }
+        (false, true, false) => {
+            if values.len() != regex_array.len() {
+                return Err(ArrowError::ComputeError(format!(
+                    "regex_array must be the same length as values array; got {} and {}",
+                    regex_array.len(),
+                    values.len(),
+                )));
+            }
+
+            let flags_array = flags_array.unwrap();
+            if values.len() != flags_array.len() {
+                return Err(ArrowError::ComputeError(format!(
+                    "flags_array must be the same length as values array; got {} and {}",
+                    flags_array.len(),
+                    values.len(),
+                )));
+            }
+
+            Ok(Arc::new(
+                izip!(values.iter(), regex_array.iter(), flags_array.iter())
+                    .map(|(value, regex, flags)| {
+                        let regex = match regex {
+                            None | Some("") => return Ok(0),
+                            Some(regex) => regex,
+                        };
+
+                        let pattern =
+                            compile_and_cache_regex(regex, flags, &mut regex_cache)?;
+
+                        count_matches(value, pattern, idx_scalar)
+                    })
+                    .collect::<Result<Int64Array, ArrowError>>()?,
+            ))
+        }
+        (false, false, true) => {
+            if values.len() != regex_array.len() {
+                return Err(ArrowError::ComputeError(format!(
+                    "regex_array must be the same length as values array; got {} and {}",
+                    regex_array.len(),
+                    values.len(),
+                )));
+            }
+
+            if values.len() != idx_array.len() {
+                return Err(ArrowError::ComputeError(format!(
+                    "idx_array must be the same length as values array; got {} and {}",
+                    idx_array.len(),
+                    values.len(),
+                )));
+            }
+
+            Ok(Arc::new(
+                izip!(values.iter(), regex_array.iter(), idx_array.iter())
+                    .map(|(value, regex, start)| {
+                        let regex = match regex {
+                            None | Some("") => return Ok(0),
+                            Some(regex) => regex,
+                        };
+
+                        let pattern = compile_and_cache_regex(
+                            regex,
+                            flags_scalar,
+                            &mut regex_cache,
+                        )?;
+                        count_matches(value, pattern, start)
+                    })
+                    .collect::<Result<Int64Array, ArrowError>>()?,
+            ))
+        }
+        (false, false, false) => {
+            if values.len() != regex_array.len() {
+                return Err(ArrowError::ComputeError(format!(
+                    "regex_array must be the same length as values array; got {} and {}",
+                    regex_array.len(),
+                    values.len(),
+                )));
+            }
+
+            if values.len() != idx_array.len() {
+                return Err(ArrowError::ComputeError(format!(
+                    "idx_array must be the same length as values array; got {} and {}",
+                    idx_array.len(),
+                    values.len(),
+                )));
+            }
+
+            let flags_array = flags_array.unwrap();
+            if values.len() != flags_array.len() {
+                return Err(ArrowError::ComputeError(format!(
+                    "flags_array must be the same length as values array; got {} and {}",
+                    flags_array.len(),
+                    values.len(),
+                )));
+            }
+
+            Ok(Arc::new(
+                izip!(
+                    values.iter(),
+                    regex_array.iter(),
+                    idx_array.iter(),
+                    flags_array.iter()
+                )
+                .map(|(value, regex, start, flags)| {
+                    let regex = match regex {
+                        None | Some("") => return Ok(0),
+                        Some(regex) => regex,
+                    };
+
+                    let pattern =
+                        compile_and_cache_regex(regex, flags, &mut regex_cache)?;
+                    count_matches(value, pattern, start)
+                })
+                .collect::<Result<Int64Array, ArrowError>>()?,
+            ))
+        }
+    }
+}
+
+fn count_matches(
+    value: Option<&str>,
+    pattern: &Regex,
+    start: Option<i64>,
+) -> Result<i64, ArrowError> {
+    let value = match value {
+        None | Some("") => return Ok(0),
+        Some(value) => value,
+    };
+
+    if let Some(start) = start {
+        if start < 1 {
+            return Err(ArrowError::ComputeError(
+                "regexp_extract() requires start to be 1 based".to_string(),
+            ));
+        }
+
+        let find_slice = value.chars().skip(start as usize - 1).collect::<String>();
+        let count = pattern.find_iter(find_slice.as_str()).count();
+        Ok(count as i64)
+    } else {
+        let count = pattern.find_iter(value).count();
+        Ok(count as i64)
+    }
+}


### PR DESCRIPTION
Add a new function, regexp_extract, that works like the function of the same name in Spark. See https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.regexp_extract.html .

## Which issue does this PR close?

This is a test assignment to demonstrate my proficiency with Rust, as well as how fast I could learn to work with a new codebase like DataFusion.

## Rationale for this change

The new function expands the functionality of DataFusion.

The code for the new function is largely copied from existing regex-related functions, namely regexp_count and regexp_replace. The _count function has more similar arguments, while the _replace has a more similar return value, so I combined the two. Copying from regexp_match and regexp_like was not useful because they are implemented in arrow, which does not have an equivalent regexp_extract.

Only the main functionality is really newly written, but that is a single-line function extract_match_inner. I also added another utility function to consolidate handling of different array types. 

Another conscious manual change was using 32-bit integers for the index. While the `start` argument of `regexp_count` can reasonably exceed 4 billion if the data strings are large, I sincerely hope that nobody has ever created nor will ever create a regular expression with 4 billion capture groups. 

This function has more functionality that its Spark equivalent - both the pattern and match index can be specified either as a scalar or as a column, while the requirements ask only for scalar values, and it can accept an optional flags argument to control exactly how the regular expression works. The main reason for all this is because existing DataFusion functions have this capability, so it was almost "free" with code reuse. In production code, I would do it the same way but for a different reason: to keep and maintain a consistent API following the principle of least surprise. 

## What changes are included in this PR?

* A new scalar function called regexp_extract.

## Are these changes tested?

Yes, by multiple test case. Like the implementation itself, the tests are heavily inspired by the tests for `regexp_count()`. 

* Tests for successfully extracting matches, for empty matches, for invalid patterns, and for invalid input types.
* Tests for individual arguments being passed as scalars or as arrays.
* Tests for case sensitivity flags.

## Are there any user-facing changes?

A new user-facing function has been added. It is documented, but I assume it also needs to be added to the changelog and user guide..

